### PR TITLE
Fix react warnings (UNSAFE_ and string ref)

### DIFF
--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -34,6 +34,7 @@ export default class GameEngine extends Component {
     this.previousTime = null;
     this.previousDelta = null;
     this.events = [];
+    this.container = new React.createRef();
   }
 
   async componentDidMount() {
@@ -146,7 +147,7 @@ export default class GameEngine extends Component {
   render() {
     return (
       <div
-        ref={"container"}
+        ref={this.container}
         style={{ ...css.container, ...this.props.style }}
         className={this.props.className}
         tabIndex={0}

--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -56,9 +56,9 @@ export default class GameEngine extends Component {
     this.timer.unsubscribe(this.updateHandler);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.running !== this.props.running) {
-      if (nextProps.running) this.start();
+  componentDidUpdate(prevProps) {
+    if (prevProps.running !== this.props.running) {
+      if (this.props.running) this.start();
       else this.stop();
     }
   }


### PR DESCRIPTION
Tested game engine today for the first time and found some react warnings.
Fixed:
1) Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code.
2) A string ref, "container", has been found within a strict mode tree. String refs are a source of potential bugs and should be avoided. We recommend using useRef() or createRef() instead.