### PR TITLE
Fixed concurrency issue with the usage of setState

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -332,15 +332,16 @@ var GameEngine = function (_Component) {
         }
       };
 
-      var newState = _this.props.systems.reduce(function (state, sys) {
-        return sys(state, args);
-      }, _this.state.entities);
-
-      _this.input.length = 0;
-      _this.events.length = 0;
-      _this.previousTime = currentTime;
-      _this.previousDelta = args.time.delta;
-      _this.setState({ entities: newState });
+      _this.setState(function (prevState) {
+        var newEntities = _this.props.systems.reduce(function (state, sys) {
+          return sys(state, args);
+        }, prevState.entities);
+        _this.input.length = 0;
+        _this.events.length = 0;
+        _this.previousTime = currentTime;
+        _this.previousDelta = args.time.delta;
+        return { entities: newEntities };
+      });
     };
 
     _this.inputHandlers = events.split(" ").map(function (name) {
@@ -360,7 +361,6 @@ var GameEngine = function (_Component) {
       entities: null
     };
     _this.timer = props.timer || new _DefaultTimer2.default();
-    _this.timer.subscribe(_this.updateHandler);
     _this.input = [];
     _this.previousTime = null;
     _this.previousDelta = null;
@@ -380,20 +380,22 @@ var GameEngine = function (_Component) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
+                this.timer.subscribe(this.updateHandler);
+
                 entities = getEntitiesFromProps(this.props);
 
                 if (!isPromise(entities)) {
-                  _context2.next = 5;
+                  _context2.next = 6;
                   break;
                 }
 
-                _context2.next = 4;
+                _context2.next = 5;
                 return entities;
 
-              case 4:
+              case 5:
                 entities = _context2.sent;
 
-              case 5:
+              case 6:
 
                 this.setState({
                   entities: entities || {}
@@ -401,7 +403,7 @@ var GameEngine = function (_Component) {
                   if (_this3.props.running) _this3.start();
                 });
 
-              case 6:
+              case 7:
               case "end":
                 return _context2.stop();
             }

--- a/src/GameEngine.js
+++ b/src/GameEngine.js
@@ -29,7 +29,6 @@ export default class GameEngine extends Component {
       entities: null
     };
     this.timer = props.timer || new DefaultTimer();
-    this.timer.subscribe(this.updateHandler);
     this.input = [];
     this.previousTime = null;
     this.previousDelta = null;
@@ -38,6 +37,8 @@ export default class GameEngine extends Component {
   }
 
   async componentDidMount() {
+    this.timer.subscribe(this.updateHandler);
+
     let entities = getEntitiesFromProps(this.props);
 
     if (isPromise(entities)) entities = await entities;
@@ -118,16 +119,17 @@ export default class GameEngine extends Component {
       }
     };
 
-    let newState = this.props.systems.reduce(
-      (state, sys) => sys(state, args),
-      this.state.entities
-    );
-
-    this.input.length = 0;
-    this.events.length = 0;
-    this.previousTime = currentTime;
-    this.previousDelta = args.time.delta;
-    this.setState({ entities: newState });
+    this.setState(prevState => {
+      let newEntities = this.props.systems.reduce(
+        (state, sys) => sys(state, args),
+        prevState.entities
+      );
+      this.input.length = 0;
+      this.events.length = 0;
+      this.previousTime = currentTime;
+      this.previousDelta = args.time.delta;
+      return { entities: newEntities};
+    });
   };
 
   inputHandlers = events


### PR DESCRIPTION
In the update handler for the game engine, the updateHandler that calls the systems, the react component method setState was used to update the state of the react component by referring to the previous state using the state property directly.

This can lead to concurrency issues that could create behaviors like the systems loop using the default state of null from the constructor and then overwriting the initial entities with null. Afterward, it may keep looping over the kept null value.

Instead of passing a value to setstate, this can be prevented by giving it a callback that will receive the latest state as argument. 
However, to use setState that way, react requires the component to be mounted. So the subscription to the timer had to be moved from constructor to componentDidMount.